### PR TITLE
Fix security callback enumeration for 32bit

### DIFF
--- a/RpcCore/RpcCore2_32bits/RpcInternals.h
+++ b/RpcCore/RpcCore2_32bits/RpcInternals.h
@@ -81,7 +81,7 @@ typedef struct _RPC_INTERFACE_T
 	ULONG						Flags;
 	ULONG						EpMapperFlags;
 	RPC_MGR_EPV PTR_T			pMgrEpv;
-	RPC_IF_CALLBACK_FN PTR_T	IfSecurityCallbackFn;
+	RPC_IF_CALLBACK_FN PTR_T	IfCallbackFn;
 	RPC_SERVER_INTERFACE_T		RpcServerInterface;
 	ULONG 						unk2[2];
 	BOOL 						bInterfaceSupportMultipleTransferSyntaxes;
@@ -91,7 +91,7 @@ typedef struct _RPC_INTERFACE_T
 	UUID_VECTOR PTR_T 			pUuidVector;
 	SIMPLE_DICT_T 				RpcInterfaceManagerDict;
 	UCHAR		 				Annotation[MAX_RPC_INTERFACE_ANNOTATION];
-	RPC_IF_CALLBACK_FN PTR_T 	IfCallbackFn;
+	RPC_IF_CALLBACK_FN PTR_T 	IfSecurityCallbackFn;
 	ULONG 						CurrentNullManagerCalls;
 	ULONG 						CurrentAutoListenCalls;
 	ULONG 						__Field_DC;

--- a/RpcCore/RpcCore3_32bits/RpcInternals.h
+++ b/RpcCore/RpcCore3_32bits/RpcInternals.h
@@ -63,7 +63,7 @@ typedef struct _RPC_INTERFACE_T
 	MUTEX_T						Mutex;
 	ULONG						EpMapperFlags;
 	RPC_MGR_EPV PTR_T			pMgrEpv;
-	RPC_IF_CALLBACK_FN PTR_T	IfSecurityCallback;
+	RPC_IF_CALLBACK_FN PTR_T	IfCallbackFn;
 	RPC_SERVER_INTERFACE_T		RpcServerInterface;
 	MIDL_SYNTAX_INFO PTR_T		pSyntaxInfo;
 	VOID PTR_T					pTransfertSyntaxes;
@@ -74,7 +74,7 @@ typedef struct _RPC_INTERFACE_T
 	UUID_VECTOR PTR_T			pUuidVector;
 	SIMPLE_DICT_T				RpcInterfaceManagerDict;
 	UCHAR						Annotation[64];
-	RPC_IF_CALLBACK_FN PTR_T	IfCallbackFn;
+	RPC_IF_CALLBACK_FN PTR_T	IfSecurityCallback;
 	ULONG						IsCallSizeLimitReached;
 	ULONG						currentNullManagerCalls;
 	ULONG						currentAutoListenCalls;

--- a/RpcCore/RpcCore4_32bits/RpcInternals.h
+++ b/RpcCore/RpcCore4_32bits/RpcInternals.h
@@ -130,7 +130,7 @@ typedef struct _RPC_INTERFACE_T
 	MUTEX_T						Mutex;
 	ULONG						EpMapperFlags;
 	RPC_MGR_EPV PTR_T			pMgrEpv;
-	RPC_IF_CALLBACK_FN PTR_T	IfSecurityCallback;
+	RPC_IF_CALLBACK_FN PTR_T	IfCallbackFn;
 	RPC_SERVER_INTERFACE_T		RpcServerInterface;
 	MIDL_SYNTAX_INFO PTR_T		pSyntaxInfo;
 	VOID PTR_T					pTransfertSyntaxes;
@@ -141,7 +141,7 @@ typedef struct _RPC_INTERFACE_T
 	UUID_VECTOR PTR_T			pUuidVector;
 	SIMPLE_DICT_T				RpcInterfaceManagerDict;
 	UCHAR						Annotation[64];
-	RPC_IF_CALLBACK_FN PTR_T	IfCallbackFn;
+	RPC_IF_CALLBACK_FN PTR_T	IfSecurityCallback;
 	ULONG						IsCallSizeLimitReached;
 	ULONG						currentNullManagerCalls;
 	ULONG						currentAutoListenCalls;


### PR DESCRIPTION
From *RpcCore2* on, the `_RPC_INTERFACE_T` structure layout seems to be incorrect regarding the security callback. I recently encountered a 32bit RPC server utilizing security callbacks and they were not displayed in *RpcView*.

The changes in this PR were confirmed to fix the issue for *RpcCore4* and probably also work for the previous two versions.